### PR TITLE
showing the "delete" and "toggleVisibility" buttons on per event "canRemoveTask()" permission basis rather than on the general condition "isAdmin()"

### DIFF
--- a/Assets/js/pam.js
+++ b/Assets/js/pam.js
@@ -1,6 +1,6 @@
 KB.on('dom.ready', function () {
     KB.onClick(".PAM_toggleVisibility", function (e) {
-      KB.http.get("/?controller=ProjectActivityModificationController&action=toggleVisibility&plugin=PAM&event_id=" + e.target.dataset.event_id);
+      KB.http.get("/?controller=ProjectActivityModificationController&action=toggleVisibility&plugin=PAM&event_id=" + e.target.dataset.event_id + "&task_id=" + e.target.dataset.task_id);
       e.target.children[0].classList.toggle('fa-eye-slash');
       e.target.children[0].classList.toggle('fa-eye');
   });

--- a/Controller/ProjectActivityModificationController.php
+++ b/Controller/ProjectActivityModificationController.php
@@ -22,18 +22,21 @@ class ProjectActivityModificationController extends BaseController
 
     public function delete()
     {
-        if ($this->userSession->isAdmin()) {
+        $task_id = $this->request->getIntegerParam('task_id');
+
+        if ( $this->helper->projectRole->canRemoveTask( $this->getTask($task_id) ) ) {
             $event_id = $this->request->getIntegerParam('event_id');
             $this->projectActivityModificationModel->delete($event_id);
         }
 
-        $task_id = $this->request->getIntegerParam('task_id');
         $this->response->redirect($this->helper->url->to('ActivityController', 'task', ['task_id' => $task_id]));
     }
 
     public function toggleVisibility()
     {
-        if ($this->userSession->isAdmin()) {
+        $task_id = $this->request->getIntegerParam('task_id');
+
+        if ( $this->helper->projectRole->canRemoveTask( $this->getTask($task_id) ) ) {
             $event_id = $this->request->getIntegerParam('event_id');
 
             $this->projectActivityModificationModel->toggleVisibility($event_id);

--- a/Template/activity/inject.php
+++ b/Template/activity/inject.php
@@ -1,10 +1,9 @@
 <?php
-if ($this->user->isAdmin()) {
-    $sub_str = '</small>';
-    $icon = 'eye-slash';
+$sub_str = '</small>';
+$icon = 'eye-slash';
 
-    foreach ($events as &$event) {
-
+foreach ($events as $index => &$event) {
+    if ($this->helper->projectRole->canRemoveTask($event['task'])) {
         if (isset($event['hidden'])) {
             $icon = 'eye';
         } else {
@@ -13,7 +12,7 @@ if ($this->user->isAdmin()) {
 
         $insert_str = '<div class="pull-right">';
 
-        $insert_str .= '<a class="btn PAM_toggleVisibility" data-event_id="' . $event['id'] . '"><i class="fa fa-fw fa-' . $icon . '" style="pointer-events: none;"></i></a>';
+        $insert_str .= '<a class="btn PAM_toggleVisibility" data-event_id="' . $event['id'] . '" data-task_id="' . $event['task_id'] . '"><i class="fa fa-fw fa-' . $icon . '" style="pointer-events: none;"></i></a>';
 
         $insert_str .= $this->helper->modal->mediumButton(
             'trash',
@@ -31,8 +30,7 @@ if ($this->user->isAdmin()) {
 
         $event['event_content'] = str_replace($sub_str, $sub_str . $insert_str, $event['event_content']);
     }
-} else {
-    foreach ($events as $index => &$event) {
+    else {
         if (isset($event['hidden'])) {
             unset($events[$index]);
         }

--- a/Template/activity/inject.php
+++ b/Template/activity/inject.php
@@ -23,7 +23,7 @@ if ($this->user->isAdmin()) {
             array(
                 'plugin' => 'PAM',
                 'event_id' => $event['id'],
-                'task_id' => $task['id'],
+                'task_id' => $event['task_id'],
             ),
         );
 


### PR DESCRIPTION
It's been a while since I've been using the plugin to hide/clear some of my task activities.

And it always bugged me a lot that I need to switch to an Admin account to perform this. Fortunately, I self-host the KB and I AM the Admin, yet I only use it for KB managing purposes. All my projects are created and managed under non-admin accounts with Manager roles, and some of them are "personal" thus don't have user roles at all and I am the sole owner and user.

So the Admin requirement for managing activity appeared quite restrictive and overwhelming for me. I did put some thought over it and I considered that relying on project-level conditions like project Owner or Manager is a bit better but still problematic - per project conditions cannot be applied for the User Activity View and would be just another hardcoded condition that comply partially with needs of the KB users. So I finally decided that it would be best if anyone who anyway has a permission to remove a specific task is absolutely eligible to also hide/clear its event activity.

Hence, the proposed implementation.
🎈